### PR TITLE
Add `/api/counter` to public routes in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,11 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
-const publicRoutes = createRouteMatcher(["/", "/api/webhooks(.*)"]);
+const publicRoutes = createRouteMatcher([
+  "/",
+  "/api/webhooks(.*)",
+  "/api/counter",
+]);
 const adminRoutes = createRouteMatcher(["/api/counter/toggle"]);
 
 export default clerkMiddleware(async (auth, req) => {


### PR DESCRIPTION
Include the `/api/counter` route in the public routes for middleware to enhance accessibility.