### PR TITLE
Add `/api/cron` to public routes in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,7 @@ const publicRoutes = createRouteMatcher([
   "/",
   "/api/webhooks(.*)",
   "/api/counter",
+  "/api/cron(.*)",
 ]);
 const adminRoutes = createRouteMatcher(["/api/counter/toggle"]);
 


### PR DESCRIPTION
Include the `/api/cron` route in the list of public routes to enhance accessibility.